### PR TITLE
minute was calculated wrong

### DIFF
--- a/lhafile/lhafile.py
+++ b/lhafile/lhafile.py
@@ -276,7 +276,7 @@ class LhaFile(object):
             month = ((ord(modify_time[3]) << 8 | ord(modify_time[2])) >> 5) & 0x0F
             day  = ord(modify_time[2]) & 0x1F
             hour = ord(modify_time[1]) >> 3
-            minute = ((ord(modify_time[1]) << 8 | ord(modify_time[0])) >> 5) & 0x2F
+            minute = ((ord(modify_time[1]) << 8 | ord(modify_time[0])) >> 5) & 0x3F
             second = (ord(modify_time[0]) & 0x1F) * 2
 
             #print(os_level, year, month, day, hour, minute, second)


### PR DESCRIPTION
i think the minute is not calculated as described in the [lha-format](https://web.archive.org/web/20021005080911/http://www.osirusoft.com/joejared/lzhformat.html).

```
 31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16
|<-------- year ------->|<- month ->|<-- day -->|

 

 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
|<--- hour --->|<---- minute --->|<- second/2 ->|
```