### PR TITLE
update: make wheels for python 3.x

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,11 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
+        uses: actions/setup-python@v3
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,26 +9,25 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist
-        twine upload dist/*
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist
+          twine upload dist/*
 
   deploy_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -38,18 +37,13 @@ jobs:
         os: [ubuntu-20.04, windows-2019, macOS-10.15]
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: "Install Visual C++ for Python 2.7"
-        if: runner.os == 'Windows'
-        run: |
-          choco install vcpython27 -f -y
+      - uses: actions/checkout@v3
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.9.0
+        run: python -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -57,15 +51,11 @@ jobs:
         # env:
         #   CIBW_SOME_OPTION: value
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Wheels
           path: ./wheelhouse/*.whl
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -39,6 +41,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.11.2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -32,13 +32,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, windows-2019, macOS-11]
 
     steps:
       - uses: actions/checkout@v3
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.11.2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, windows-2019, macOS-11]
 
     steps:
       - uses: actions/checkout@v3
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.11.2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,6 +19,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.11.2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,18 +15,13 @@ jobs:
         os: [ubuntu-20.04, windows-2019, macOS-10.15]
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: "Install Visual C++ for Python 2.7"
-        if: runner.os == 'Windows'
-        run: |
-          choco install vcpython27 -f -y
+      - uses: actions/checkout@v3
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.9.0
+        run: python -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -34,7 +29,7 @@ jobs:
         # env:
         #   CIBW_SOME_OPTION: value
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Wheels
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
`pip install lhafile` occurs the following error in Win10, because lhafile doesn't  provide enough wheels for recent python 3.X .

> error: Microsoft Visual C++ 14.0 is required. Get it with "Microsoft Visual
C++ Build Tools": http://landinghub.visualstudio.com/visual-cpp-build-tools

I just update actions. See result of my action below.
https://github.com/eholic/python-lhafile/actions/runs/3608798558